### PR TITLE
Single file workflow

### DIFF
--- a/.github/workflows/trigger-postman-single-file.yml
+++ b/.github/workflows/trigger-postman-single-file.yml
@@ -1,0 +1,39 @@
+name: "Generate single file"
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      file:
+        description: 'OpenAPI filepath'     
+        required: true
+        default: 'adyen-openapi/yaml/CheckoutService-v70.yaml'
+jobs:
+  generate:
+    name: "Generate Postman Collection"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/checkout@v3
+        with:
+          repository: 'Adyen/adyen-openapi'
+          fetch-depth: 0
+          path: 'adyen-openapi'
+      - uses: addnab/docker-run-action@v3
+        with:
+          image: gcatanese/openapi-generator-postman-v2
+          options: -v ${{ github.workspace }}:/usr/src/app
+          run: |
+            /usr/src/app/generateSingleFile.sh ${{ github.event.inputs.file }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Manual generation"
+      - name: push-adyen-collections-to-postman-javascript-action
+        id: process
+        uses: jlengrand/push-adyen-collections-to-postman-javascript-action@main
+        with:
+          postman-key: ${{ secrets.POSTMAN_API_KEY }}
+          workspace-id: ${{ secrets.POSTMAN_WORKSPACE_ID }}
+          path-to-process: "./postman"

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,14 +7,16 @@ __NOTE : This part is meant for the authors of that repository and you probably 
 Most of the magic here resides in the [trigger-postman.yml](./.github/workflows/trigger-postman.yml) workflow.
 This workflow can either be triggered [directly from the UI](https://github.com/Adyen/adyen-postman/actions/workflows/trigger-postman.yml), though typically it is automatically triggered every time the [adyen-openapi](https://github.com/Adyen/adyen-openapi/blob/main/.github/workflows/notify.yml) repository is updated.
 
+An additional workflow [trigger-postman-single-file.yml](./.github/workflows/trigger-postman-single-file.yml) is provided to run the generation for a specific OpenAPI file that can be passed as parameter.
 
-It relies on two different custom actions : 
+
+Both workflow use two different custom actions : 
 
 * The [openapi-generator-postman-v2](https://github.com/gcatanese/openapi-generator-postman-v2) which is used to transform OpenAPI specifications into a Postman compatible format.
 * The [push-adyen-collections-to-postman-javascript-action](https://github.com/jlengrand/push-adyen-collections-to-postman-javascript-action/) which uses the Postman API to push those files to the [Postman AdyenDev workspace](https://www.postman.com/adyendev/workspace/adyen-apis/overview).
 
 
-## Workflow (see [trigger-postman.yml](./.github/workflows/trigger-postman.yml))
+## Workflow trigger-postman (see [trigger-postman.yml](./.github/workflows/trigger-postman.yml))
 
 When the workflow gets triggered :
 
@@ -32,6 +34,20 @@ When the workflow gets triggered :
         * If a new API is detected, uploads it to the AdyenDev workspace as a new collection
         * If a newer version of an existing API is detected, patches the existing collection to the newer version
 
+## Workflow trigger-postman-single-file (see [trigger-postman-single-file.yml](./.github/workflows/trigger-postman-single-file.yml))
+
+When the workflow runs :
+
+* The `generate` job will be fired
+    * This job first runs a script relying on [openapi-generator-postman-v2](https://github.com/gcatanese/openapi-generator-postman-v2). This script will take the file passed as parameter (ie `adyen-openapi/yaml/CheckoutService-v70.yaml) and generate a corresponding Postman compatible version.
+        *  The `generateSingleFile.sh` script contains a list of `postmanVariables` and `generatedVariables` that are needed to create the variables in the Postman format.
+    * The generated JSON file when it has changed (been modified, or added) is committed to the repository. 
+    * Then, the [push-adyen-collections-to-postman-javascript-action](https://github.com/jlengrand/push-adyen-collections-to-postman-javascript-action/) action will be run. This action : 
+        * Takes all Postman files in the repository
+        * Finds the highest version of each file for each API 
+        * If a new API is detected, uploads it to the AdyenDev workspace as a new collection
+        * If a newer version of an existing API is detected, patches the existing collection to the newer version
+
 ## Repository secrets
  
 Two repository secrets are necessary to successfully run this action : 
@@ -41,17 +57,19 @@ Two repository secrets are necessary to successfully run this action :
 
 ## Scripts
 
-Two custom scripts are present in the repository
+The repository includes multiple scripts:
 
 * `generateAll.sh` generates all postman API collection files for all versions of the OpenAPI definitions and places them in the postman folder. It is meant to run inside the [dedicated docker image](https://github.com/gcatanese/openapi-generator-postman-v2/).
 * `runDocker.sh` is the script that actually runs `generateAll.sh` inside the docker image. 
+* `generateSingleFile.sh` generates the postman API collection for a given OpenAPI file and places it in the postman folder. It is meant to run inside the [dedicated docker image](https://github.com/gcatanese/openapi-generator-postman-v2/).
+* `runDockerSingleFile.sh` is the script that actually runs `generateSingleFile.sh` inside the docker image. 
 
 ## Running locally
 
 If necessary, the scripts can be run locally to achieve the same results. 
 
-* To generate Postman JSON files, one can run the `runDocker.sh` script. (Docker needs to be installed and started). 
-    * Once the generation is done, the updated files can be committed.
+* To generate Postman JSON files, one can run the `runDocker.sh` or `runDockerSingleFile.sh` script. (Docker needs to be installed and started). 
+    * Once the generation is done, the updated file(s) can be committed.
 * To push the collections to Postman, see the documentation of [push-adyen-collections-to-postman-javascript-action/](https://github.com/jlengrand/push-adyen-collections-to-postman-javascript-action/).
 
 Note that both scripts _should_ be safe to run without issues . The generation can be reversed via git, and you can use a dummy workspace ID for the postman script to push to a safe place for testing.

--- a/generateSingleFile.sh
+++ b/generateSingleFile.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Generate Postman Collection from a given OpenAPI file
+#
+
+# Sets working tools
+if [[ $OSTYPE == 'darwin'* ]]; then
+  echo "MacOS detected. Alias sed to gsed."
+  alias sed=gsed
+fi
+
+DATE=$(date +"%Y-%m-%d")
+
+echo "Generate Postman Collection from $1"
+FILENAME=$1
+BASE=$(echo "$(basename "${FILENAME%.*}")")
+NAME=$(echo $FILENAME | sed 's/-.*//' | sed 's/.*\///')
+REAL_NAME=$(sed '/title:/!d;q' $FILENAME | sed 's/.*://')
+VERSION=$(echo $FILENAME | sed 's/.*-v//' | sed 's/\..*//')
+
+#  echo "Generating $FILENAME $BASE $NAME $REAL_NAME $VERSION $DATE"
+
+sed -i.bak "1s/.*/openapi: 3.0.3/" $FILENAME # downgrade version for compat
+sed -i.bak2 "0,/title:.*/{s//title: $REAL_NAME\ (v$VERSION)/}" $FILENAME # Set unique name of API for Postman
+
+/script.sh generate \
+    --additional-properties postmanVariables=YOUR_MERCHANT_ACCOUNT-YOUR_COMPANY_ACCOUNT-YOUR_BALANCE_PLATFORM,generatedVariables=YOUR_REFERENCE_NUMBER-YOUR_REFERENCE-YOUR_ORDER_NUMBER-YOUR_ORDER_NUMBER\
+    -i $FILENAME \
+    -o postman/$BASE
+
+mv postman/$BASE/postman.json postman/$BASE.json
+rm -rf postman/$BASE

--- a/runDockerSingleFile.sh
+++ b/runDockerSingleFile.sh
@@ -1,0 +1,10 @@
+  #!/bin/sh
+
+if [ ! -d /adyen-openapi ]; then
+  git clone https://github.com/Adyen/adyen-openapi.git
+fi
+
+docker run --volume $(pwd):/usr/src/app --entrypoint /usr/src/app/generateSingleFile.sh gcatanese/openapi-generator-postman-v2 $1
+
+# clean up
+rm -rf adyen-openapi


### PR DESCRIPTION
Add workflow to process a single file - to be passed as a parameter in the GitHub action

This will allow running ad-hoc generation in case a file spec needs to be processed/regenerated again


