### PR TITLE
Remove OpenAPI version downgrading

### DIFF
--- a/generateAll.sh
+++ b/generateAll.sh
@@ -23,7 +23,6 @@ do
 
     #  echo "Generating $FILENAME $BASE $NAME $REAL_NAME $VERSION $DATE"
 
-    sed -i.bak "1s/.*/openapi: 3.0.3/" $FILENAME # downgrade version for compat
     sed -i.bak2 "0,/title:.*/{s//title: $REAL_NAME\ (v$VERSION)/}" $FILENAME # Set unique name of API for Postman
 
     /script.sh generate \


### PR DESCRIPTION
This PR removes the replacement of `3.1.0` with `3.0.3` precedently implemented because the OpenAPI generator didn't support `v3.1.0`.